### PR TITLE
Handle UUID's as path values

### DIFF
--- a/lib/ecto_materialized_path/path.ex
+++ b/lib/ecto_materialized_path/path.ex
@@ -7,7 +7,7 @@ defmodule EctoMaterializedPath.Path do
   """
 
   def cast(list) when is_list(list) do
-    path_is_correct? = Enum.all?(list, fn(path_id) -> is_integer(path_id) end)
+    path_is_correct? = Enum.all?(list, fn(path_id) -> (is_integer(path_id) || is_binary(path_id)) end)
 
     if path_is_correct? do
       { :ok, list }

--- a/test/ecto_materialized_path/path_test.exs
+++ b/test/ecto_materialized_path/path_test.exs
@@ -11,11 +11,15 @@ defmodule EctoMaterializedPath.PathTest do
     assert Path.cast([13, 45, 18]) == { :ok, [13, 45, 18] }
   end
 
+  test "passes with UUID's" do
+    assert Path.cast(["38432046-4351-4676-8988-10f0262da113", "a65ce828-52f2-4931-8719-9f7d97723f3b"]) == { :ok, ["38432046-4351-4676-8988-10f0262da113", "a65ce828-52f2-4931-8719-9f7d97723f3b"] }
+  end
+
   test "fails with random value" do
     assert Path.cast(4) == :error
   end
 
   test "fails with wrongs path" do
-    assert Path.cast([14, "ee", 45]) == :error
+    assert Path.cast([14, [:ok], 45]) == :error
   end
 end


### PR DESCRIPTION
When using UUID's as a table's primary key it currently fails because of the check if path values are integers.

Extended to check if path values are either integer or binaries.

